### PR TITLE
שינוי שם התכונה "דיוק"

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -7964,7 +7964,7 @@ StatsTextStrings:
 	db "הגנה@"
 	db "מהירות@"
 	db "מיוחדת@"
-	db "דיוק@"
+	db "דייקנות@"
 	db "התחמקות@"
 
 StatModifierRatios:


### PR DESCRIPTION
כל התכונות, מלבד "דיוק", רשומות בלשון נקבה. לכן בקרב ניתן לראות לעיתים משפטים כמו:
"ההתקפה של גחומט הופחתה"
או
"ההגנה של גלגולם גדלה"
כאשר האפקט פועל על דיוק המשפט הופך ללא תחבירי.
הצעות נוספות מלבד דייקנות: צליפה, פגיעה