### PR TITLE
The NES bootleg sold in Hebrew speaking countries is the Megason.

### DIFF
--- a/text.asm
+++ b/text.asm
@@ -808,7 +808,7 @@ _IndigoPlateauHQText::
 
 _RedBedroomSNESText::
 	text "<PLAYER> משחק"
-	line "בSENS!"
+	line "במגאסון!"
 	cont "...אוקיי!"
 	cont "צריך ללכת!"
 	done


### PR DESCRIPTION
There is no SNES variant as far as I know.