### PR TITLE
Fixed ghost name

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6908,11 +6908,11 @@ InitWildBattle:
 	ld [hl], b
 	ld hl, wEnemyMonNick  ; set name to "GHOST"
 	ld a, "ר"
-	ld [hld], a
+	ld [hli], a
 	ld a, "ו"
-	ld [hld], a
+	ld [hli], a
 	ld a, "ח"
-	ld [hld], a
+	ld [hli], a
 	ld [hl], "@"
 	ld a, [wcf91]
 	push af


### PR DESCRIPTION
כשאין משקף בתיק, רוחות מופיעות בתור ראד:
![radGhost1](https://user-images.githubusercontent.com/12798171/85327733-22eb4100-b4d8-11ea-979c-c9ecedbe1fb2.png)
![radGhost2](https://user-images.githubusercontent.com/12798171/85327729-2252aa80-b4d8-11ea-8103-17d74b6ea6be.png)

בקומיט האחרון שהתייחס לשורות הרלוונטיות, נראה שכשתורגם השם שלה, הוחלפה הפקודה
`ld [hli], a`
ב-
`ld [hld], a`

אז החזרתי אותה בחזרה
 