### PR TITLE
Fixed PC text, solved bug in foe's item usage

### DIFF
--- a/data/text/text_2.asm
+++ b/data/text/text_2.asm
@@ -16,11 +16,11 @@ _FemaleAIBattleWithdrawText::
 
 _MaleAIBattleUseItemText::
 	text_ram wTrainerName
-	text "@"
+	text_start
 	line "השתמש"
 	cont "ב@"
 	text_ram wcd6d
-	text "@"
+	text_start
 	cont "על @"
 	text_ram wEnemyMonNick
 	text "!"
@@ -28,11 +28,11 @@ _MaleAIBattleUseItemText::
 
 _FemaleAIBattleUseItemText::
 	text_ram wTrainerName
-	text "@"
+	text_start
 	line "השתמשה"
 	cont "ב@"
 	text_ram wcd6d
-	text "@"
+	text_start
 	cont "על @"
 	text_ram wEnemyMonNick
 	text "!"
@@ -1545,9 +1545,10 @@ _DepositHowManyText::
 	done
 
 _ItemWasStoredText::
+	text "איחסנת במחשב"
+	line "@"
 	text_ram wcd6d
-	text ""
-	line "מאוחסן במחשב."
+	text "."
 	prompt
 
 _NothingToDepositText::
@@ -1729,7 +1730,7 @@ _GetDexRatedText::
 
 _ClosedOaksPCText::
 	text "החיבור למחשב של"
-	line "פרופ' אלון נסדר.@"
+	line "פרופ' אלון נסגר.@"
 	text_end
 
 _AccessedOaksPCText::


### PR DESCRIPTION
Item bug - When Misty tried to use X Defend, after printing טל, the game would freeze, the music will turn to random Pokemon cries for a few moments, and eventually the battle will continue, without loading the text of "השתמשה בהגנה על כוכיש". When comparing the code to pret's, I found the `text_start` command , added [here](https://github.com/Nog-Frog/pokered/commit/139a28ff9906d728a6820fe678a2a616eb309421), got lost in this [merge](https://github.com/Nog-Frog/pokered/commit/d33ef867324ee7f1d1631e31ca8a0b838199a17c). 
It's possible more bugs will be caused by not using `text_start`. If I'll encounter any weird text loading bug, I'll know where to look.

PC - typo, replaced passive gendered "אוחסן".
